### PR TITLE
feat: DEVOPS-29 rename validator to insights mcp server + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# validator-mcp-server
+# Zilliqa Insights MCP Server
+
+The Zilliqa Insights [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) Server is a component designed to provide LLM interaction with Zilliqa validator nodes observability metrics.
+
+## Available Tools
+
+This server exposes several tools that query validator performance and status metrics. These tools act as a proxy, connecting to the downstream `observability-mcp` server, which is part of the [`gcloud-mcp`](https://github.com/Zilliqa/gcloud-mcp), to retrieve data from Google Cloud Monitoring.
+
+-   **`getTotalValidatorEarnings(validator, startTime?, endTime?)`**
+    -   Retrieves the total ZIL rewards earned by a specific validator within a given time frame. Defaults to the last hour if no time is specified.
+
+-   **`getValidatorEarningsBreakdown(validator, startTime?, endTime?)`**
+    -   Provides a detailed breakdown of a validator's earnings, separating rewards from block proposals and cosignatures.
+
+-   **`getValidatorStake(public_key)`**
+    -   Fetches the total amount of ZIL currently delegated (staked) to a validator, which represents their weight in the consensus mechanism.
+
+-   **`getProposerSuccessRate(public_key, startTime?, endTime?)`**
+    -   Calculates the success rate for a validator when they are tasked with proposing a new block. This is a critical indicator of node stability and network latency.
+
+-   **`getCosignerSuccessRate(public_key, startTime?, endTime?)`**
+    -   Measures the validator's success rate for cosigning (attesting to) blocks proposed by others. This demonstrates consistent uptime and connectivity.
+
+## Technical Requirements
+
+To run this project, you will need the following installed on your system:
+
+- **Node.js**: Version `20` or higher (`node > 20`).
+
+## Development
+
+Follow these instructions to get the server running on your local machine for development and testing purposes.
+
+### 1. Installation
+
+First, install the project dependencies using npm:
+
+```bash
+npm install
+```
+
+### 2. Build
+
+Next, compile the TypeScript source code into JavaScript:
+
+```bash
+npm run build
+```
+
+This will create a `build` directory containing the distributable files.
+
+### 3. Running the Server
+
+The server can operate in two modes:
+- **`stdio` mode**: The server communicates over standard input/output. This is typically used for direct interaction with the MCP server on the same machine. This is the default option.
+- **`http` mode**: The server exposes an HTTP API, allowing for remote communication and management from other services.
+
+```bash
+node build/index.js
+```
+
+To run the server in HTTP streamable mode add the `--http` flag:
+
+```bash
+node build/index.js --http
+```
+
+Add this configuration in the Gemini local settings to test the MCP server:
+
+```json
+"mcpServers": {
+  "insights-local": {
+    "httpUrl": "http://localhost:3001/mcp"
+  }
+}
+```
+
+## Deployment
+
+### Kubernetes
+
+The Kubernetes manifests for deploying this server are located in the `cd/` directory. Environment-specific configurations can be found in `cd/overlays/`.
+
+### Staging Environment
+
+A staging version of this server is automatically deployed via GitHub Actions pipelines. The deployment is triggered on pushes to the main branch.
+
+The staging instance is accessible at the following URL:
+
+- **URL**: https://insights.mcp.zilstg.dev/mcp
+
+Add this configuration in the Gemini local settings to test the MCP server:
+
+```json
+"mcpServers": {
+  "insights": {
+    "httpUrl": "https://insights.mcp.zilstg.dev/mcp"
+  }
+}
+```

--- a/cd/base/configmap.yaml
+++ b/cd/base/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: validator-mcp-server
-  namespace: validator-mcp-server
+  name: insights-mcp-server
+  namespace: insights-mcp-server
   labels:
-    app.kubernetes.io/name: validator-mcp-server
+    app.kubernetes.io/name: insights-mcp-server
 data:
   PORT: "3001"

--- a/cd/base/deployment.yaml
+++ b/cd/base/deployment.yaml
@@ -1,30 +1,30 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: validator-mcp-server
-  namespace: validator-mcp-server
+  name: insights-mcp-server
+  namespace: insights-mcp-server
   labels:
-    app.kubernetes.io/name: validator-mcp-server
+    app.kubernetes.io/name: insights-mcp-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: validator-mcp-server
+      app.kubernetes.io/name: insights-mcp-server
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: validator-mcp-server
+        app.kubernetes.io/name: insights-mcp-server
     spec:
       containers:
-        - name: validator-mcp-server
-          image: validator-mcp-server
+        - name: insights-mcp-server
+          image: insights-mcp-server
           ports:
             - containerPort: 3001
               name: http
               protocol: TCP
           envFrom:
             - configMapRef:
-                name: validator-mcp-server
+                name: insights-mcp-server
           resources:
             requests:
               memory: "128Mi"

--- a/cd/base/healthcheckpolicy.yaml
+++ b/cd/base/healthcheckpolicy.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:
-  name: validator-mcp-server
-  namespace: validator-mcp-server
+  name: insights-mcp-server
+  namespace: insights-mcp-server
   labels:
-    app.kubernetes.io/name: validator-mcp-server
+    app.kubernetes.io/name: insights-mcp-server
 spec:
   default:
     checkIntervalSec: 10
@@ -20,4 +20,4 @@ spec:
   targetRef:
     group: ""
     kind: Service
-    name: validator-mcp-server
+    name: insights-mcp-server

--- a/cd/base/httproute.yaml
+++ b/cd/base/httproute.yaml
@@ -1,18 +1,18 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: validator-mcp-server
-  namespace: validator-mcp-server
+  name: insights-mcp-server
+  namespace: insights-mcp-server
   labels:
-    app.kubernetes.io/name: validator-mcp-server
+    app.kubernetes.io/name: insights-mcp-server
 spec:
   parentRefs:
     - name: mcp-gateway
       namespace: mcp-gateway-stg
       sectionName: https
   hostnames:
-    - "validator.mcp.zilstg.dev"
+    - "insights.mcp.zilstg.dev"
   rules:
     - backendRefs:
-        - name: validator-mcp-server
+        - name: insights-mcp-server
           port: 3001

--- a/cd/base/namespace.yaml
+++ b/cd/base/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: validator-mcp-server
+  name: insights-mcp-server

--- a/cd/base/service.yaml
+++ b/cd/base/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: validator-mcp-server
-  namespace: validator-mcp-server
+  name: insights-mcp-server
+  namespace: insights-mcp-server
   labels:
-    app.kubernetes.io/name: validator-mcp-server
+    app.kubernetes.io/name: insights-mcp-server
 spec:
   type: ClusterIP
   ports:
@@ -14,4 +14,4 @@ spec:
       name: http
       appProtocol: HTTP
   selector:
-    app.kubernetes.io/name: validator-mcp-server
+    app.kubernetes.io/name: insights-mcp-server

--- a/cd/overlays/production/kustomization.yaml
+++ b/cd/overlays/production/kustomization.yaml
@@ -4,16 +4,16 @@ kind: Kustomization
 resources:
   - ../../base
 
-namespace: validator-mcp-server-prd
+namespace: insights-mcp-server-prd
 
 patches:
   - target:
       kind: HTTPRoute
-      name: validator-mcp-server
+      name: insights-mcp-server
     patch: |-
       - op: replace
         path: "/spec/hostnames/0"
-        value: validator.mcp.zilliqa.com
+        value: insights.mcp.zilliqa.com
       - op: replace
         path: "/spec/parentRefs/0/name"
         value: mcp-gateway
@@ -22,7 +22,7 @@ patches:
         value: mcp-gateway-prd
   - target:
       kind: ConfigMap
-      name: validator-mcp-server
+      name: insights-mcp-server
     patch: |-
       - op: add
         path: /data/OBSERVABILITY_MCP_URL

--- a/cd/overlays/staging/kustomization.yaml
+++ b/cd/overlays/staging/kustomization.yaml
@@ -4,16 +4,16 @@ kind: Kustomization
 resources:
   - ../../base
 
-namespace: validator-mcp-server-stg
+namespace: insights-mcp-server-stg
 
 patches:
   - target:
       kind: HTTPRoute
-      name: validator-mcp-server
+      name: insights-mcp-server
     patch: |-
       - op: replace
         path: "/spec/hostnames/0"
-        value: validator.mcp.zilstg.dev
+        value: insights.mcp.zilstg.dev
       - op: replace
         path: "/spec/parentRefs/0/name"
         value: mcp-gateway
@@ -22,7 +22,7 @@ patches:
         value: mcp-gateway-stg
   - target:
       kind: ConfigMap
-      name: validator-mcp-server
+      name: insights-mcp-server
     patch: |-
       - op: add
         path: /data/OBSERVABILITY_MCP_URL


### PR DESCRIPTION
- Renaming validator MCP to insights MCP.
- Adding the documentation for usage and explanation: https://github.com/Zilliqa/validator-mcp-server/blob/devops-29/README.md
- Will rename the repo after this PR is merged.