### PR TITLE
Revert "fix: real ip from the x-forward-ip header"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ async function main() {
         // Endpoint for StreamableHTTP connection (GET)
         app.get('/mcp', (req: Request, res: Response) => {
             // Get real client IP (supports proxies/load balancers)
-            const realIp = req.headers['x-forwarded-for']?.toString().split(',')[1]?.trim() || req.ip;
+            const realIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.ip;
             logger.debug(`Received GET connection request from ${realIp}`);
 
             // Server MUST either return 'text/event-stream' or 405 Method Not Allowed.
@@ -76,7 +76,7 @@ async function main() {
 
         // Main MCP endpoint - stateless mode (POST)
         app.post('/mcp', async (req: Request, res: Response) => {
-            const realIp = req.headers['x-forwarded-for']?.toString().split(',')[1]?.trim() || req.ip;
+            const realIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.ip;
             logger.debug(`Received POST MCP request from ${realIp}`);
             
             try {


### PR DESCRIPTION
Reverts Zilliqa/insights-mcp-server#14

Not working as expected we will review the global cases for the balancer headers.